### PR TITLE
Add gallery component

### DIFF
--- a/src/components/Gallery.astro
+++ b/src/components/Gallery.astro
@@ -1,0 +1,10 @@
+---
+---
+<section id="gallery" class="grid grid-cols-2 sm:grid-cols-3 gap-4 my-8">
+    <img src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=400&q=80" alt="Dichter Wald" class="w-full h-auto object-cover" />
+    <img src="https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&q=80" alt="Waldweg" class="w-full h-auto object-cover" />
+    <img src="https://images.unsplash.com/photo-1507668077129-56aaa942b9a1?auto=format&fit=crop&w=400&q=80" alt="Forstarbeiter" class="w-full h-auto object-cover" />
+    <img src="https://images.unsplash.com/photo-1517074820444-4005561d7735?auto=format&fit=crop&w=400&q=80" alt="Holzernte" class="w-full h-auto object-cover" />
+    <img src="https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=400&q=80" alt="Bäume im Morgenlicht" class="w-full h-auto object-cover" />
+    <img src="https://images.unsplash.com/photo-1519817914152-22d216bb9170?auto=format&fit=crop&w=400&q=80" alt="Forstwirtschaft" class="w-full h-auto object-cover" />
+</section>

--- a/src/components/Welcome.astro
+++ b/src/components/Welcome.astro
@@ -1,10 +1,12 @@
 ---
 import Hero from './Hero.astro';
+import Gallery from './Gallery.astro';
 import Contact from './Contact.astro';
 ---
 <div id="container">
     <main>
         <Hero />
+        <Gallery />
         <Contact />
     </main>
 </div>


### PR DESCRIPTION
## Summary
- add `Gallery` component with 6 forestry-related images
- show the new gallery between `Hero` and `Contact`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68458d3933588327824932554fd76d0d