### PR TITLE
Add margin above hero logo

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,7 +2,9 @@
 import Logo from './Logo.astro';
 ---
 <section id="hero" class="flex flex-col items-center">
-    <Logo />
+    <div class="mt-10">
+        <Logo />
+    </div>
     <h1 class="text-4xl mb-3">Paul Diermair</h1>
     <h1 class="text-2xl mb-8">Forstwart & Forstwirtschaftsmeister</h1>
 </section>


### PR DESCRIPTION
## Summary
- add a wrapper with `mt-10` to space the Hero logo from the top

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6845b2b009548327a9f99dbc6523e1e9