### PR TITLE
Add footer component and Impressum page

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,6 @@
+---
+---
+<footer class="w-full text-center py-4">
+    <a href="/impressum">Impressum</a>
+</footer>
+

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import Footer from "../components/Footer.astro";
 
 interface Props {
 	title: string;
@@ -47,9 +48,9 @@ const { title } = Astro.props;
 			}
 		</script>
 	</head>
-	<body
-		class="flex justify-center items-center min-h-screen m-4 font-sans fill-green-900 text-green-900 dark:fill-gray-200 dark:text-gray-200 bg-gray-200 dark:bg-green-900 transition-colors duration-300"
-	>
+       <body
+               class="flex flex-col items-center min-h-screen m-4 font-sans fill-green-900 text-green-900 dark:fill-gray-200 dark:text-gray-200 bg-gray-200 dark:bg-green-900 transition-colors duration-300"
+       >
 		<button
 			class="absolute top-7 right-7 bg-gray-800 dark:bg-gray-500 p-2 rounded-lg"
 			toggle-mode-button
@@ -58,8 +59,9 @@ const { title } = Astro.props;
 			<span class="hidden dark:block">☀️</span>
 		</button>
 
-		<slot />
-	</body>
+               <slot />
+               <Footer class="mt-auto" />
+       </body>
 </html>
 
 <style>

--- a/src/pages/impressum.astro
+++ b/src/pages/impressum.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Impressum">
+    <h1>Impressum</h1>
+</Layout>
+


### PR DESCRIPTION
## Summary
- add a reusable `Footer` component with a link to Impressum
- include `Footer` in the site layout
- create a simple Impressum page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6845b5e58e208327a37c4c3a961577cd