### PR TITLE
Add Tailwind color palette

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,26 @@
+import { defineConfig } from 'tailwindcss'
+
+export default defineConfig({
+  content: ['./src/**/*.{astro,html,js,jsx,ts,tsx,vue,svelte}'],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: '#196622',
+          dark: '#144D1A',
+          light: '#4A7744',
+        },
+        accent: {
+          lime: '#A7DC81',
+          amber: '#F4B860',
+          berry: '#A44A6E',
+        },
+        neutral: {
+          50: '#F7F7F5',
+          400: '#B2B2B2',
+          900: '#2C2C2C',
+        },
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- create `tailwind.config.mjs` and include the brand, accent, and neutral colors

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6845dab113088327a23c2dac82884b18