### PR TITLE
Remove dark mode compatibility

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -49,16 +49,9 @@ const { title } = Astro.props;
 		</script>
 	</head>
        <body
-               class="flex flex-col items-center min-h-screen m-4 font-sans fill-green-900 text-green-900 dark:fill-gray-200 dark:text-gray-200 bg-gray-200 dark:bg-green-900 transition-colors duration-300"
+               class="flex flex-col items-center min-h-screen m-4 font-sans fill-green-900 text-green-900 bg-gray-200 transition-colors duration-300"
        >
-		<button
-			class="absolute top-7 right-7 bg-gray-800 dark:bg-gray-500 p-2 rounded-lg"
-			toggle-mode-button
-		>
-			<span class="block dark:hidden">🌙</span>
-			<span class="hidden dark:block">☀️</span>
-		</button>
-
+		
                <slot />
                <Footer class="mt-auto" />
        </body>
@@ -73,23 +66,3 @@ const { title } = Astro.props;
 	}
 </style>
 
-<script>
-	const theme = localStorage.getItem("theme");
-        if (
-                theme === "dark" ||
-                (localStorage.getItem("theme") === null &&
-                        window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-                document.documentElement.classList.add("dark");
-        }
-
-        function toggleTheme() {
-                const isDarkMode = document.documentElement.classList.toggle("dark");
-                localStorage.setItem("theme", isDarkMode ? "dark" : "light");
-        }
-
-	const buttons = document.querySelectorAll("[toggle-mode-button]");
-	buttons.forEach((button) => {
-		button.addEventListener("click", toggleTheme);
-	});
-</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,5 @@
 @import "tailwindcss";
 
-@custom-variant dark (&:where(.dark, .dark *));
 
 /*
   The default border color has changed to `currentColor` in Tailwind CSS v4,


### PR DESCRIPTION
## Summary
- remove dark mode variant from global styles
- strip theme toggle button and script from main layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6845db05176c83278c67e08a59c9f122