### PR TITLE
Add Datenschutzerklärung page and footer link

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,6 +2,7 @@
 const { class: className = "" } = Astro.props;
 ---
 <footer class={`w-full text-center py-4 ${className}`.trim()}>
-    <a href="/impressum">Impressum</a>
+    <a href="/impressum" class="mr-2">Impressum</a>
+    <a href="/datenschutzerklaerung">Datenschutzerklärung</a>
 </footer>
 

--- a/src/pages/datenschutzerklaerung.astro
+++ b/src/pages/datenschutzerklaerung.astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Datenschutzerklärung">
+    <h1>Datenschutzerklärung</h1>
+</Layout>


### PR DESCRIPTION
## Summary
- add link to `Datenschutzerklärung` in footer
- add new `Datenschutzerklärung` page with a heading

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6845de501c1c832789c30d9725a471c3