### PR TITLE
Fix left alignment of Impressum text

### DIFF
--- a/src/pages/impressum.astro
+++ b/src/pages/impressum.astro
@@ -3,26 +3,28 @@ import Layout from '../layouts/Layout.astro';
 ---
 
 <Layout title="Impressum">
-    <h1>Impressum</h1>
-    <p><strong>Angaben gemäß § 5 E-Commerce-Gesetz (ECG) und § 24 Mediengesetz</strong></p>
+    <div class="text-left">
+        <h1>Impressum</h1>
+        <p><strong>Angaben gemäß § 5 E-Commerce-Gesetz (ECG) und § 24 Mediengesetz</strong></p>
 
-    <p><strong>Name:</strong><br />Paul Diermair</p>
+        <p><strong>Name:</strong><br />Paul Diermair</p>
 
-    <p><strong>Gewerbeberechtigung:</strong><br />Holzschlägerung, -bringung und -zerkleinerung (freies Gewerbe)</p>
+        <p><strong>Gewerbeberechtigung:</strong><br />Holzschlägerung, -bringung und -zerkleinerung (freies Gewerbe)</p>
 
-    <p><strong>Standort des Unternehmens:</strong><br />Höhnhart 87<br />5251 Höhnhart<br />Österreich</p>
+        <p><strong>Standort des Unternehmens:</strong><br />Höhnhart 87<br />5251 Höhnhart<br />Österreich</p>
 
-    <p><strong>Kontakt:</strong><br />📞 Telefon: +43 676 / 6331513<br />📧 E-Mail: <a href="mailto:diermair.waldbewirtschaftung@gmail.com">diermair.waldbewirtschaftung@gmail.com</a></p>
+        <p><strong>Kontakt:</strong><br />📞 Telefon: +43 676 / 6331513<br />📧 E-Mail: <a href="mailto:diermair.waldbewirtschaftung@gmail.com">diermair.waldbewirtschaftung@gmail.com</a></p>
 
-    <p><strong>GISA-Zahl:</strong><br />37137632</p>
+        <p><strong>GISA-Zahl:</strong><br />37137632</p>
 
-    <p><strong>Zuständige Behörde gemäß ECG:</strong><br />Bezirkshauptmannschaft Braunau</p>
+        <p><strong>Zuständige Behörde gemäß ECG:</strong><br />Bezirkshauptmannschaft Braunau</p>
 
-    <p><strong>Mitglied bei:</strong><br />Wirtschaftskammer Oberösterreich, Sparte Gewerbe und Handwerk</p>
+        <p><strong>Mitglied bei:</strong><br />Wirtschaftskammer Oberösterreich, Sparte Gewerbe und Handwerk</p>
 
-    <p><strong>Hinweis gemäß ODR-Verordnung:</strong><br />Verbraucher haben die Möglichkeit, Beschwerden an die Online-Streitbeilegungsplattform der EU zu richten:<br /><a href="https://ec.europa.eu/odr">https://ec.europa.eu/odr</a><br />Wir sind jedoch nicht verpflichtet und nicht bereit, an einem Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.</p>
+        <p><strong>Hinweis gemäß ODR-Verordnung:</strong><br />Verbraucher haben die Möglichkeit, Beschwerden an die Online-Streitbeilegungsplattform der EU zu richten:<br /><a href="https://ec.europa.eu/odr">https://ec.europa.eu/odr</a><br />Wir sind jedoch nicht verpflichtet und nicht bereit, an einem Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.</p>
 
-    <hr />
+        <hr />
 
-    <p>Dieses Impressum gilt auch für alle zugehörigen Onlinepräsenzen, sofern nicht anders angegeben.</p>
+        <p>Dieses Impressum gilt auch für alle zugehörigen Onlinepräsenzen, sofern nicht anders angegeben.</p>
+    </div>
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -97,3 +97,7 @@ body {
 .margin-right-small {
   margin-right: 0.5rem;
 }
+
+.text-left {
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- ensure Impressum page content is left aligned
- add CSS helper class `text-left` for left alignment

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684676ab1aac8327b3ea1f0eb7561e4b