### PR TITLE
Fix hero subtitle layout on mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -44,8 +44,10 @@ body {
 }
 
 .hero-subtitle {
-  font-size: 1.5rem;
+  font-size: clamp(1rem, 5vw, 1.5rem);
   margin-bottom: 2rem;
+  white-space: nowrap;
+  padding: 0 0.5rem;
 }
 
 .logo {


### PR DESCRIPTION
## Summary
- keep hero subtitle on a single line on small screens
- add responsive font size and padding

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6846790decd08327935ea184e131c541