### PR TITLE
Add sticky navigation bar

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,0 +1,10 @@
+---
+const { class: className = "" } = Astro.props;
+---
+<nav class={`navbar ${className}`.trim()}>
+  <ul>
+    <li><a href="#hero">Start</a></li>
+    <li><a href="#gallery">Fotos</a></li>
+    <li><a href="#contact">Kontakt</a></li>
+  </ul>
+</nav>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/global.css";
 import Footer from "../components/Footer.astro";
+import Navbar from "../components/Navbar.astro";
 
 interface Props {
 	title: string;
@@ -49,7 +50,8 @@ const { title } = Astro.props;
 		</script>
 	</head>
        <body>
-		
+
+               <Navbar />
                <slot />
                <Footer class="mt-auto" />
        </body>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -103,3 +103,34 @@ body {
 .text-left {
   text-align: left;
 }
+
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  width: 100%;
+  background-color: var(--gray-bg);
+  padding: 0.5rem 0;
+}
+
+.navbar ul {
+  list-style: none;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.navbar a {
+  color: var(--green-color);
+  text-decoration: none;
+  font-weight: bold;
+}
+
+@media (max-width: 639px) {
+  .navbar ul {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Navbar component with section links
- include the Navbar in the main layout
- style the Navbar and make it sticky at the top of the page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6846801eba60832785c9a55a46ca00f3