### PR TITLE
Add responsive hamburger navbar

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -2,9 +2,20 @@
 const { class: className = "" } = Astro.props;
 ---
 <nav class={`navbar ${className}`.trim()}>
-  <ul>
-    <li><a href="#hero">Start</a></li>
+  <a href="#hero" class="nav-home">Start</a>
+  <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-label="Menü öffnen">&#9776;</button>
+  <ul class="nav-links">
     <li><a href="#gallery">Fotos</a></li>
     <li><a href="#contact">Kontakt</a></li>
   </ul>
 </nav>
+
+<script>
+  const toggle = document.getElementById('nav-toggle');
+  const nav = toggle?.closest('.navbar');
+  toggle?.addEventListener('click', () => {
+    nav?.classList.toggle('open');
+    const isOpen = nav?.classList.contains('open');
+    toggle.setAttribute('aria-expanded', isOpen);
+  });
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -124,27 +124,58 @@ body {
   z-index: 10;
   width: 100%;
   background-color: var(--gray-bg);
-  padding: 0.5rem 0;
-}
-
-.navbar ul {
-  list-style: none;
+  padding: 0.5rem 1rem;
   display: flex;
-  justify-content: center;
-  gap: 1rem;
-  margin: 0;
-  padding: 0;
+  align-items: center;
 }
 
-.navbar a {
+.nav-home {
+  margin-right: auto;
   color: var(--green-color);
   text-decoration: none;
   font-weight: bold;
 }
 
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links a {
+  color: var(--green-color);
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--green-color);
+  cursor: pointer;
+}
+
 @media (max-width: 639px) {
-  .navbar ul {
-    flex-wrap: wrap;
-    gap: 0.5rem;
+  .nav-links {
+    display: none;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    flex-direction: column;
+    background-color: var(--gray-bg);
+    padding: 0.5rem 1rem;
+  }
+
+  .navbar.open .nav-links {
+    display: flex;
+  }
+
+  .nav-toggle {
+    display: block;
+    margin-left: auto;
   }
 }


### PR DESCRIPTION
## Summary
- update Navbar component with start link left and a mobile hamburger menu
- style navbar for desktop and mobile

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684683071068832780e284523fd3c612