### PR TITLE
Fix card widths

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -44,6 +44,7 @@ body {
   margin-top: 0.5rem;
   width: 100%;
   max-width: 20rem;
+  box-sizing: border-box;
 }
 
 .contact-card a {
@@ -141,7 +142,7 @@ body {
   width: 100%;
   margin-top: 1rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
   gap: 1rem;
 }
 
@@ -153,6 +154,7 @@ body {
   text-align: center;
   width: 100%;
   max-width: 20rem;
+  box-sizing: border-box;
 }
 
 .navbar {


### PR DESCRIPTION
## Summary
- style: use border-box for cards to keep equal width
- style: enforce 20rem grid column width for service cards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68469418be688327ab09c62c955088ed