### PR TITLE
Use logo in navbar

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,8 +1,9 @@
 ---
 const { class: className = "" } = Astro.props;
+import Logo from './Logo.astro';
 ---
 <nav class={`navbar ${className}`.trim()}>
-  <a href="#hero" class="nav-home">Start</a>
+  <a href="#hero" class="nav-home"><Logo /></a>
   <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-label="Menü öffnen">&#9776;</button>
   <ul class="nav-links">
     <li><a href="#gallery">Fotos</a></li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -155,10 +155,10 @@ body {
 }
 
 .nav-home {
-  margin-right: auto;
-  color: var(--green-color);
+  flex: 1;
+  display: flex;
+  justify-content: center;
   text-decoration: none;
-  font-weight: bold;
 }
 
 .nav-links {
@@ -166,6 +166,7 @@ body {
   display: flex;
   gap: 1rem;
   margin: 0;
+  margin-left: auto;
   padding: 0;
 }
 


### PR DESCRIPTION
## Summary
- load the `Logo` component in `Navbar` and use it as the home link
- flexbox adjustments so the logo centers in the navbar

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6846b934448483278edc5805ae9e3f50