### PR TITLE
Add scroll-driven navbar logo shrinking

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -30,4 +30,24 @@ import Logo from './Logo.astro';
       }
     });
   });
+
+  const logo = nav?.querySelector('.logo');
+  if (nav && logo) {
+    const fontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+    const targetSize = 3.5 * fontSize;
+    const startSize = logo.offsetHeight;
+    const navExtraHeight = nav.offsetHeight - startSize;
+    nav.style.height = `${nav.offsetHeight}px`;
+
+    const updateSize = () => {
+      const scrollY = window.scrollY;
+      const newSize = Math.max(startSize - scrollY, targetSize);
+      logo.style.width = `${newSize}px`;
+      logo.style.height = `${newSize}px`;
+      nav.style.height = `${navExtraHeight + newSize}px`;
+    };
+
+    updateSize();
+    window.addEventListener('scroll', updateSize);
+  }
 </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -83,6 +83,10 @@ body {
   }
 }
 
+.navbar .logo {
+  margin-bottom: 0;
+}
+
 #gallery {
   overflow: hidden;
   padding: 2rem 0;


### PR DESCRIPTION
## Summary
- implement scroll-based logo resizing in Navbar
- prevent bottom margin on navbar logo

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6846be4b60448327babc2ee3c9873180