### PR TITLE
Add size prop to Logo component

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -27,7 +27,7 @@ import Logo from './Logo.astro';
 
 <section id="hero">
     <div class="hero-logo">
-        <Logo />
+        <Logo size="30rem" />
     </div>
     <h1 class="hero-title">Paul Diermair</h1>
     <h1 class="hero-subtitle">Forstwart & Forstwirtschaftsmeister</h1>

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -1,13 +1,13 @@
 ---
-
+const { size = "200mm" } = Astro.props;
 ---
 
 <svg
 	class="logo"
 	xmlns="http://www.w3.org/2000/svg"
 	xml:space="preserve"
-	width="200mm"
-	height="200mm"
+	width={size}
+	height={size}
 	version="1.1"
 	style="shape-rendering:geometricPrecision; text-rendering:geometricPrecision; image-rendering:optimizeQuality; fill-rule:evenodd; clip-rule:evenodd"
 	viewBox="0 0 20000 20000"
@@ -344,16 +344,8 @@
 <style>
 .logo {
   display: block;
-  width: 13rem;
-  height: 13rem;
   margin-bottom: 2.5rem;
 }
 
-@media (min-width: 640px) {
-  .logo {
-    width: 20rem;
-    height: 20rem;
-  }
-}
 
 </style>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -3,7 +3,7 @@ const { class: className = "" } = Astro.props;
 import Logo from './Logo.astro';
 ---
 <nav class={`navbar ${className}`.trim()}>
-  <a href="#hero" class="nav-home"><Logo /></a>
+  <a href="#hero" class="nav-home"><Logo size="4rem" /></a>
   <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-label="Menü öffnen">&#9776;</button>
   <ul class="nav-links">
     <li><a href="#gallery">Fotos</a></li>


### PR DESCRIPTION
## Summary
- add size prop to `Logo` and use it for width & height
- remove fixed sizing from `Logo` styles
- specify logo size in `Hero` and `Navbar`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6847152c69f08327beb982343785d4f0