### PR TITLE
Fix mobile card width overflow

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,12 @@ body {
   height: 100%;
 }
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- use universal `box-sizing: border-box` so card padding doesn't expand past the viewport

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6847f9a8bba88327b0385d62c377bd16