### PR TITLE
Add SVG icons to services

### DIFF
--- a/src/components/Leistungen.astro
+++ b/src/components/Leistungen.astro
@@ -2,18 +2,34 @@
     <h2>Leistungen</h2>
     <div class="leistungen-grid">
         <div class="leistung-card">
+            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M2 5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6l-4 4V5z" />
+            </svg>
             <h3>Beratung</h3>
             <p>Individuelle Beratung für eine nachhaltige Waldbewirtschaftung.</p>
         </div>
         <div class="leistung-card">
+            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M3 2l7 7-1 1 5 5 2-2 3 3-2 2-3-3-2 2-5-5-1 1-7-7z" />
+            </svg>
             <h3>Holzernte</h3>
             <p>Effiziente und schonende Holzernte mit moderner Technik.</p>
         </div>
         <div class="leistung-card">
+            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true">
+                <circle cx="12" cy="12" r="6" fill="none" stroke-width="2" stroke="currentColor" />
+                <line x1="12" y1="3" x2="12" y2="7" stroke-width="2" stroke="currentColor" />
+                <line x1="12" y1="17" x2="12" y2="21" stroke-width="2" stroke="currentColor" />
+                <line x1="3" y1="12" x2="7" y2="12" stroke-width="2" stroke="currentColor" />
+                <line x1="17" y1="12" x2="21" y2="12" stroke-width="2" stroke="currentColor" />
+            </svg>
             <h3>Spezialbaumfällung</h3>
             <p>Fachgerechtes Fällen von Problembäumen auch in schwierigem Gelände.</p>
         </div>
         <div class="leistung-card">
+            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 2c-5 5-8 10 0 16 8-6 5-11 0-16z" />
+            </svg>
             <h3>Waldpflege</h3>
             <p>Pflegearbeiten für gesunde und stabile Waldbestände.</p>
         </div>


### PR DESCRIPTION
## Summary
- add simple SVG icons above each service title

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6848020bed1483279c6301217122eb95