### PR TITLE
Add Holzernte SVG and use with Astro Image

### DIFF
--- a/src/Images/holzernte.svg
+++ b/src/Images/holzernte.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="200" height="100"
+     viewBox="0 0 200 100">
+  <!-- Kettensägen-Gehäuse -->
+  <rect x="10" y="30" width="100" height="40"
+        fill="#666" stroke="#333" stroke-width="2"/>
+  <!-- Griff -->
+  <rect x="35" y="15" width="20" height="20"
+        fill="#333" stroke="#000" stroke-width="2"
+        rx="3" ry="3"/>
+  <!-- Kettenrad -->
+  <circle cx="150" cy="50" r="30"
+          fill="none" stroke="#333" stroke-width="4"/>
+  <!-- Zahnbesatz der Kette -->
+  <g stroke="#333" stroke-width="4">
+    <line x1="180" y1="50" x2="195" y2="50"/>
+    <line x1="155" y1="80" x2="163" y2="88"/>
+    <line x1="125" y1="80" x2="118" y2="88"/>
+    <line x1="118" y1="20" x2="125" y2="30"/>
+    <line x1="155" y1="20" x2="163" y2="12"/>
+  </g>
+</svg>

--- a/src/components/Leistungen.astro
+++ b/src/components/Leistungen.astro
@@ -1,3 +1,8 @@
+---
+import { Image } from 'astro:assets';
+import HolzernteIcon from '../Images/holzernte.svg';
+---
+
 <section id="leistungen">
     <h2>Leistungen</h2>
     <div class="leistungen-grid">
@@ -9,9 +14,7 @@
             <p>Individuelle Beratung für eine nachhaltige Waldbewirtschaftung.</p>
         </div>
         <div class="leistung-card">
-            <svg width="40" height="40" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M2 11h8v2H2z M10 9h4v6h-4z M14 11h6v2h-6z M20 10h2v4h-2z" />
-            </svg>
+            <Image src={HolzernteIcon} alt="" width={40} height={40} />
             <h3>Holzernte</h3>
             <p>Effiziente und schonende Holzernte mit moderner Technik.</p>
         </div>


### PR DESCRIPTION
## Summary
- add chainsaw SVG as Holzernte logo
- use Astro image capabilities in `Leistungen` component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68480946401c832793126bed936a32e8