### PR TITLE
Fix navbar icon alignment

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -49,6 +49,7 @@ import Logo from './Logo.astro';
 
   .nav-home {
     display: flex;
+    align-items: center;
     text-decoration: none;
   }
 
@@ -69,6 +70,9 @@ import Logo from './Logo.astro';
 
   .nav-toggle {
     display: none;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
     background: none;
     border: none;
     font-size: 1.5rem;
@@ -92,7 +96,8 @@ import Logo from './Logo.astro';
     }
 
     .nav-toggle {
-      display: block;
+      display: flex;
+      align-items: center;
       margin-left: auto;
     }
   }


### PR DESCRIPTION
## Summary
- ensure the nav logo and mobile toggle are vertically centered

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_684872a30f1483278c27a79cb9aa1f31