### PR TITLE
Fix chainsaw icon color

### DIFF
--- a/src/images/chainsaw-tool-svgrepo-com.svg
+++ b/src/images/chainsaw-tool-svgrepo-com.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-<svg fill="#000000" height="800px" width="800px" version="1.1" id="Icons" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+<svg fill="currentColor" height="800px" width="800px" version="1.1" id="Icons" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
 	 viewBox="0 0 32 32" xml:space="preserve">
 <path d="M26,13h-9v-2c0-0.6-0.4-1-1-1V8c0-1.7-1.3-3-3-3h-2C9.3,5,8,6.3,8,8v1v1.5V14c0,0.6-0.4,1-1,1c-0.6,0-1-0.4-1-1v-2.2
 	l-0.5,0.3l-2.6,1.5c-1.8,1.1-2.9,3-2.9,5.1V19c0,3.3,2.7,6,6,6h10c0.1,0,0.1,0,0.2,0c0.1,0,0.2,0,0.3,0H26c3.3,0,6-2.7,6-6


### PR DESCRIPTION
## Summary
- use `currentColor` for chainsaw SVG so it follows the site's green theme

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68494d4a9bf88327b5c274b99894d13c