### PR TITLE
Fix navbar link order

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -9,9 +9,10 @@ import Logo from '../images/Logo.svg';
   </a>
   <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-label="Menü öffnen">&#9776;</button>
   <ul class="nav-links">
-    <li><a href="#gallery">Fotos</a></li>
     <li><a href="#leistungen">Leistungen</a></li>
+    <li><a href="#ueber-mich">Über mich</a></li>
     <li><a href="#contact">Kontakt</a></li>
+    <li><a href="#gallery">Fotos</a></li>
   </ul>
 </nav>
 


### PR DESCRIPTION
## Summary
- add missing "Über mich" link in `Navbar.astro`
- reorder navigation links to match the layout of `index.astro`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_684f05ea86708327a034230a286b9c79