### PR TITLE
Add screen reader heading in hero

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -19,6 +19,7 @@ import Logo from '../images/Logo.svg';
 </style>
 
 <section id="hero">
+    <h1 class="sr-only">Diermair Waldbewirtschaftung</h1>
     <div class="hero-logo">
         <Logo class="logo" />
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,6 +35,20 @@ body {
   margin-right: 0.5rem;
 }
 
-.text-left {
-  text-align: left;
+  .text-left {
+    text-align: left;
+  }
+
+/* Utility class for screen reader only content */
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(1px, 1px, 1px, 1px) !important;
+  clip-path: inset(50%) !important;
+  border: 0 !important;
+  white-space: nowrap !important;
 }


### PR DESCRIPTION
## Summary
- add invisible heading to Hero component
- add screen-reader style class to global CSS

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_684f0791e4d48327afa71d3176827b98