### PR TITLE
Hide figcaption in hero

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -25,7 +25,7 @@ const logoAltText =
     <h1 class="sr-only">Diermair Waldbewirtschaftung</h1>
     <figure class="hero-logo">
         <Logo class="logo" alt={logoAltText} />
-        <figcaption>
+        <figcaption class="sr-only">
             {logoAltText}
         </figcaption>
     </figure>


### PR DESCRIPTION
## Summary
- hide figcaption content in Hero component so it doesn't render visually

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684fa726f3cc83279082c605d3f23bab