### PR TITLE
Add card reveal animation

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -90,13 +90,26 @@ const { title } = Astro.props;
 			}
 		</script>
 	</head>
-	<body>
-		<Navbar />
-		<main class="main-content">
-			<slot />
-		</main>
-		<Footer class="mt-auto footer-spacing" />
-	</body>
+        <body>
+                <Navbar />
+                <main class="main-content">
+                        <slot />
+                </main>
+                <Footer class="mt-auto footer-spacing" />
+                <script is:inline>
+                        const observer = new IntersectionObserver((entries) => {
+                                entries.forEach((entry) => {
+                                        if (entry.isIntersecting) {
+                                                entry.target.classList.add("show");
+                                        } else {
+                                                entry.target.classList.remove("show");
+                                        }
+                                });
+                        });
+
+                        document.querySelectorAll(".card").forEach((card) => observer.observe(card));
+                </script>
+        </body>
 </html>
 <style>
 	.main-content {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -60,4 +60,12 @@ body {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   padding: 2rem;
   text-align: center;
+  opacity: 0;
+  transform: translateY(1rem);
+  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+}
+
+.card.show {
+  opacity: 1;
+  transform: translateY(0);
 }


### PR DESCRIPTION
## Summary
- animate card components with 0.5s fade and slide when entering viewport
- observe all `.card` elements to toggle show class on intersection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b0a308865c83279064cc9c1184d0c8