### PR TITLE
Toggle navbar logo when hero is out of view

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -97,7 +97,8 @@ const { title } = Astro.props;
                 </main>
                 <Footer class="mt-auto footer-spacing" />
                 <script is:inline>
-                        const observer = new IntersectionObserver((entries) => {
+                        // Reveal cards when they enter the viewport
+                        const cardObserver = new IntersectionObserver((entries) => {
                                 entries.forEach((entry) => {
                                         if (entry.isIntersecting) {
                                                 entry.target.classList.add("show");
@@ -106,8 +107,29 @@ const { title } = Astro.props;
                                         }
                                 });
                         });
+                        document
+                                .querySelectorAll(".card")
+                                .forEach((card) => cardObserver.observe(card));
 
-                        document.querySelectorAll(".card").forEach((card) => observer.observe(card));
+                        // Toggle navbar logo based on hero logo visibility
+                        const heroLogo = document.querySelector("#hero .logo");
+                        const navLogo = document.querySelector(".navbar .logo");
+
+                        if (heroLogo && navLogo) {
+                                const logoObserver = new IntersectionObserver((entries) => {
+                                        entries.forEach((entry) => {
+                                                if (entry.isIntersecting) {
+                                                        navLogo.style.visibility = "hidden";
+                                                        navLogo.style.opacity = "0";
+                                                } else {
+                                                        navLogo.style.visibility = "visible";
+                                                        navLogo.style.opacity = "1";
+                                                }
+                                        });
+                                });
+
+                                logoObserver.observe(heroLogo);
+                        }
                 </script>
         </body>
 </html>


### PR DESCRIPTION
## Summary
- reveal cards on scroll with IntersectionObserver
- hide navbar logo while hero logo is visible, show it once hero leaves viewport

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b352c016f88327ae5539e43829669c